### PR TITLE
新增容器宽度调整功能，修复gitlab10.x的小问题

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -561,3 +561,13 @@ a.gitlabTreeView_toggle {
   border: 1px solid #e5e5e5;
   color: rgba(0, 0, 0, 0.85);
 }
+
+.gitlabTreeView_resizable {
+  position: absolute;
+  width: 5px;
+  height: 100%;
+  top: 0;
+  right: 0;
+  cursor: col-resize;
+  z-index: 9999;
+}


### PR DESCRIPTION
1. gitlab 10.x 不会遮挡 header 和 sidebar
2. 新增容器宽度调整功能(resizable)