### PR TITLE
fix: 获取文件目录api参数为ref

### DIFF
--- a/main.js
+++ b/main.js
@@ -101,7 +101,7 @@ var vm = {
         var param = {
             id: vm.project_id,
             recursive: true,
-            ref_name: vm.repository_ref
+            ref: vm.repository_ref
         };
 
         if (vm.rss_mode) {


### PR DESCRIPTION
参考 [https://docs.gitlab.com/ee/api/v3_to_v4.html](https://docs.gitlab.com/ee/api/v3_to_v4.html)

`GET /projects/:id/repository/tree` parameter `ref_name` has been renamed to `ref` for consistency

影响分支的读取